### PR TITLE
Tweak shopping cart state initialisation

### DIFF
--- a/src/contexts/CartContext.js
+++ b/src/contexts/CartContext.js
@@ -1,20 +1,12 @@
-import React, { createContext, useReducer } from 'react';
+import React, { createContext, useEffect, useReducer } from 'react';
 import { CartReducer, sumItems } from './CartReducer';
 
 export const CartContext = createContext();
 
-const storage =
-  typeof window !== 'undefined' && localStorage.getItem('cart')
-    ? JSON.parse(localStorage.getItem('cart'))
-    : [];
-const initialState = {
-  cartItems: storage,
-  ...sumItems(storage),
-  checkout: false,
-};
-
 const CartContextProvider = ({ children }) => {
-  const [state, dispatch] = useReducer(CartReducer, initialState);
+  const [state, dispatch] = useReducer(CartReducer, {
+    cartItems: []
+  });
 
   const increase = (payload) => {
     console.log('INCREASE');
@@ -45,6 +37,25 @@ const CartContextProvider = ({ children }) => {
     console.log('CHECKOUT', state);
     dispatch({ type: 'CHECKOUT' });
   };
+
+  const initialise = (payload) => {
+    console.log('INITIALISE', payload);
+    dispatch({ type: 'INITIALISE', payload });
+  };
+
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const cartItems = localStorage.getItem('cart') ? JSON.parse(localStorage.getItem('cart')) : [];
+    const payload = {
+      cartItems,
+      ...sumItems(cartItems),
+      checkout: false
+    }
+
+    initialise(payload);
+  }, []);
 
   const contextValues = {
     removeProduct,

--- a/src/contexts/CartReducer.js
+++ b/src/contexts/CartReducer.js
@@ -78,6 +78,10 @@ export const CartReducer = (state, action) => {
         cartItems: [],
         ...sumItems([]),
       };
+    case 'INITIALISE':
+      return {
+        ...action.payload
+      };
     default:
       return state;
   }


### PR DESCRIPTION
I've ripped out the default state initialisation and replaced it with a `useEffect` that will run on the first render (both on the client and server). 

I'm not seeing the console warnings on my side anymore, and this is the only way to both render the UI on the server, and then hydrate it with appropriate data on the frontend.

Data also persists between full page refreshes.