### PR TITLE
Checkout Process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Sample Images/
 node_modules/
 .env.*
 .env.build
+next.config.js
 
 npm-debug.log*
 yarn-debug.log*

--- a/pages/api/createOrder.js
+++ b/pages/api/createOrder.js
@@ -33,12 +33,4 @@ export default async (req, res) => {
   } catch (err) {
     console.log('Error ocurred: ', err);
   }
-  // const json = await res.json();
-
-  // if (json.errors) {
-  //   console.log('Error Details');
-  //   console.log(json.errors);
-  //   throw new Error('Failed to fetch API');
-  // }
-  // return json.data;
 };

--- a/pages/api/createOrder.js
+++ b/pages/api/createOrder.js
@@ -1,0 +1,44 @@
+const WOOCOMMERCE_URL = process.env.WOOCOMMERCE_URL;
+const WOOCOMMERCE_CONSUMER_KEY = process.env.WOOCOMMERCE_CONSUMER_KEY;
+const WOOCOMMERCE_CONSUMER_SECRET = process.env.WOOCOMMERCE_CONSUMER_SECRET;
+const WOOCOMMERCE_VERSION = process.env.WOOCOMMERCE_VERSION;
+const WOOCOMMERCE_AUTH_KEY = process.env.WOOCOMMERCE_AUTH_TOKEN;
+
+export default async (req, res) => {
+  const headers = {
+    Authorization: WOOCOMMERCE_AUTH_KEY,
+    'Content-Type': 'application/json',
+  };
+
+  const FINAL_URL = WOOCOMMERCE_URL + '/wp-json/' + WOOCOMMERCE_VERSION + '/orders';
+  try {
+    console.log(WOOCOMMERCE_AUTH_KEY);
+    console.log(FINAL_URL);
+
+    const response = await fetch(FINAL_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(req.body),
+    });
+
+    console.log(response);
+
+    if (response.status === 200 || response.status === 201) {
+      res.statusCode = response.status === 200 ? 200 : 201;
+      res.end();
+    } else {
+      res.statusCode = 400;
+      res.end();
+    }
+  } catch (err) {
+    console.log('Error ocurred: ', err);
+  }
+  // const json = await res.json();
+
+  // if (json.errors) {
+  //   console.log('Error Details');
+  //   console.log(json.errors);
+  //   throw new Error('Failed to fetch API');
+  // }
+  // return json.data;
+};

--- a/pages/checkout/failure.js
+++ b/pages/checkout/failure.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Failure() {
+  return <h1>Woops, something went wrong!</h1>;
+}

--- a/pages/checkout/index.js
+++ b/pages/checkout/index.js
@@ -1,0 +1,36 @@
+import React, { useContext, useState } from 'react';
+
+import { CartContext } from '../../src/contexts/CartContext';
+
+import { Link } from 'next/link';
+import Button from '@material-ui/core/Button';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormLabel from '@material-ui/core/FormLabel';
+
+export default function Checkout() {
+  const { total, cartItems, checkout, handleCheckout } = useContext(CartContext);
+
+  const [paymentMethod, setPaymentMethod] = useState('paypal');
+
+  const handleChange = (e) => {
+    setPaymentMethod(e.target.value);
+  };
+
+  return (
+    <div>
+      <div>Checkout Page</div>
+      <div>Total: {total}</div>
+      <FormControl component="fieldset">
+        <FormLabel component="legend">Payment Method</FormLabel>
+        <RadioGroup aria-label="payment-method" name="payment-method" value={paymentMethod} onChange={handleChange}>
+          <FormControlLabel value="paypal" control={<Radio />} label="Paypal" />
+          <FormControlLabel value="cash" control={<Radio />} label="Cash" />
+        </RadioGroup>
+      </FormControl>
+      <Button>Checkout</Button>
+    </div>
+  );
+}

--- a/pages/checkout/index.js
+++ b/pages/checkout/index.js
@@ -18,6 +18,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Typography from '@material-ui/core/Typography';
 import InputLabel from '@material-ui/core/InputLabel';
 import { getMenu } from '../../lib/api';
+import { useRouter } from 'next/router';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -36,6 +37,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function Checkout() {
+  const router = useRouter();
   const { total, cartItems, checkout, handleCheckout } = useContext(CartContext);
 
   const [paymentMethod, setPaymentMethod] = useState('cash');
@@ -97,9 +99,9 @@ export default function Checkout() {
         });
 
         if (res.status === 200 || res.status === 201) {
-          console.log('Great Success');
+          router.push('/checkout/success');
         } else {
-          console.log('Great Failure');
+          router.push('/checkout/failure');
         }
       } catch (err) {
         console.log('Error Frontend: ', err);

--- a/pages/checkout/index.js
+++ b/pages/checkout/index.js
@@ -2,6 +2,8 @@ import React, { useContext, useState } from 'react';
 
 import { CartContext } from '../../src/contexts/CartContext';
 
+import { makeStyles } from '@material-ui/core/styles';
+
 import { Link } from 'next/link';
 import Button from '@material-ui/core/Button';
 import Radio from '@material-ui/core/Radio';
@@ -9,28 +11,72 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  textField: {
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+  },
+  gridItem: {
+    marginBottom: theme.spacing(1),
+  },
+}));
 
 export default function Checkout() {
   const { total, cartItems, checkout, handleCheckout } = useContext(CartContext);
 
   const [paymentMethod, setPaymentMethod] = useState('paypal');
 
-  const handleChange = (e) => {
+  const [{ firstName, surname, email, phoneNumber, address }, setCheckoutInformation] = useState({});
+
+  const classes = useStyles();
+
+  const handlePaymentChange = (e) => {
     setPaymentMethod(e.target.value);
   };
 
+  const handleTextFieldChange = (key) => (e) => {
+    const { value } = e.target;
+
+    setCheckoutInformation((old) => ({
+      ...old,
+      [key]: value,
+    }));
+  };
+
   return (
-    <div>
-      <div>Checkout Page</div>
-      <div>Total: {total}</div>
-      <FormControl component="fieldset">
-        <FormLabel component="legend">Payment Method</FormLabel>
-        <RadioGroup aria-label="payment-method" name="payment-method" value={paymentMethod} onChange={handleChange}>
-          <FormControlLabel value="paypal" control={<Radio />} label="Paypal" />
-          <FormControlLabel value="cash" control={<Radio />} label="Cash" />
-        </RadioGroup>
-      </FormControl>
-      <Button>Checkout</Button>
-    </div>
+    <Grid container direction="row">
+      <Grid item xs={12} className={classes.gridItem}>
+        <h1>Checkout Page</h1>
+      </Grid>
+      <Grid item xs={12} className={classes.gridItem}>
+        <p>Total: {total}</p>
+      </Grid>
+      <Grid item xs={12} className={classes.gridItem}>
+        <TextField required id="name" label="First Name" variant="standard" className={classes.textField} onChange={handleTextFieldChange('firstName')} />
+        <TextField required id="surname" label="Surname" variant="standard" className={classes.textField} onChange={handleTextFieldChange('surname')} />
+        <TextField required id="email" label="Email Address" variant="standard" className={classes.textField} onChange={handleTextFieldChange('email')} />
+        <TextField required id="phoneNumber" label="Phone Number" variant="standard" className={classes.textField} onChange={handleTextFieldChange('phoneNumber')} />
+        <TextField required id="addressLine1" label="Address Line 1" variant="standard" className={classes.textField} onChange={handleTextFieldChange('address')} />
+      </Grid>
+      <Grid item xs={12} className={classes.gridItem}>
+        <FormControl component="fieldset">
+          <FormLabel component="legend">Payment Method</FormLabel>
+          <RadioGroup aria-label="payment-method" name="payment-method" value={paymentMethod} onChange={handlePaymentChange}>
+            <FormControlLabel value="paypal" control={<Radio />} label="Paypal" />
+            <FormControlLabel value="cash" control={<Radio />} label="Cash" />
+          </RadioGroup>
+        </FormControl>
+      </Grid>
+      <Grid item xs={12} className={classes.gridItem}>
+        <Button>Checkout</Button>
+      </Grid>
+    </Grid>
   );
 }

--- a/pages/checkout/success.js
+++ b/pages/checkout/success.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Success() {
+  return <h1>Order Success!</h1>;
+}


### PR DESCRIPTION
Add the checkout page to the web application. The form added captures all the required details to create an order on WooCommerce. The order is created via a REST API in the `pages/api/createOrder` file. Only cash payment is currently implemented. @daveGrayMac will start working on PayPal integration next. Added `success` and `failure` routes as well depending on whether the order is created successfully or not.