### PR TITLE
Add Product Variations

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -5,13 +5,14 @@ const API_URL = process.env.WP_API_URL;
 const WOOCOMMERCE_URL = process.env.WOOCOMMERCE_URL;
 const WOOCOMMERCE_CONSUMER_KEY = process.env.WOOCOMMERCE_CONSUMER_KEY;
 const WOOCOMMERCE_CONSUMER_SECRET = process.env.WOOCOMMERCE_CONSUMER_SECRET;
-const WOOCOMMERCE_VERISON = process.env.WOOCOMMERCE_VERISON;
+const WOOCOMMERCE_VERSION = process.env.WOOCOMMERCE_VERSION;
+const WOOCOMMERCE_AUTH_KEY = process.env.WOOCOMMERCE_AUTH_TOKEN;
 
 const wooCommerceApi = new WooCommerceRestApi({
   url: WOOCOMMERCE_URL,
   consumerKey: WOOCOMMERCE_CONSUMER_KEY,
   consumerSecret: WOOCOMMERCE_CONSUMER_SECRET,
-  version: WOOCOMMERCE_VERISON,
+  version: WOOCOMMERCE_VERSION,
 });
 
 async function fetchAPI(query, { variables } = {}) {
@@ -137,9 +138,37 @@ export async function getProducts() {
 
 export async function getProduct(productID) {
   try {
-    const json = await wooCommerceApi.get(`products/${productID}`);
-    return json.data;
+    const headers = {
+      Authorization: WOOCOMMERCE_AUTH_KEY,
+      'Content-Type': 'application/json',
+    };
+
+    const PRODUCT_URL = `${WOOCOMMERCE_URL}/wp-json/${WOOCOMMERCE_VERSION}/products/${productID}`;
+    const VARIATIONS_URL = `${PRODUCT_URL}/variations`;
+
+    const [product, productVariations] = await Promise.all([
+      fetch(PRODUCT_URL, {
+        method: 'GET',
+        headers,
+      }),
+      fetch(VARIATIONS_URL, {
+        method: 'GET',
+        headers,
+      }),
+    ])
+      .then((responses) => {
+        return Promise.all(
+          responses.map((response) => {
+            return response.json();
+          }),
+        );
+      })
+      .catch((error) => {
+        console.log('Promise Error: Woopsie Doopsie Oopsie ', error);
+      });
+
+    return { product: product, variations: productVariations };
   } catch (err) {
-    console.log(err);
+    console.log('Some other Error: ', err);
   }
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -156,13 +156,7 @@ export async function getProduct(productID) {
         headers,
       }),
     ])
-      .then((responses) => {
-        return Promise.all(
-          responses.map((response) => {
-            return response.json();
-          }),
-        );
-      })
+      .then((responses) => Promise.all(responses.map((response) => response.json())))
       .catch((error) => {
         console.log('Promise Error: Woopsie Doopsie Oopsie ', error);
       });

--- a/pages/checkout/index.js
+++ b/pages/checkout/index.js
@@ -77,7 +77,7 @@ export default function Checkout() {
         phone: phoneNumber,
       };
 
-      const lineItems = cartItems.map((item) => ({ product_id: item.id, quantity: item.quantity }));
+      const lineItems = cartItems.map((item) => ({ product_id: item.product_id, variation_id: item.id, quantity: item.quantity }));
 
       const data = {
         payment_method: 'cod',

--- a/pages/shop/[pid].js
+++ b/pages/shop/[pid].js
@@ -30,7 +30,7 @@ export default function Product({ productData, variationData }) {
   const [quantity, setQuantity] = useState(0);
   const [size, setSize] = useState('A2');
 
-  let startPrice = variationData.filter((item) => item.attributes[0].option === 'A2')[0].price;
+  let startPrice = variationData.find((item) => item.attributes[0].option === 'A2').price;
   const [price, setPrice] = useState(startPrice);
 
   const isInCart = (product) => {
@@ -38,7 +38,7 @@ export default function Product({ productData, variationData }) {
   };
 
   const addToCart = (productData) => {
-    const selectedVariation = variationData.filter((item) => item.attributes[0].option === size)[0];
+    const selectedVariation = variationData.find((item) => item.attributes[0].option === size) || {};
 
     selectedVariation.quantity = quantity;
     selectedVariation.product_id = productData.id;
@@ -47,9 +47,9 @@ export default function Product({ productData, variationData }) {
   };
 
   const handleChange = (e) => {
-    const target = e.target;
+    const { target } = e;
 
-    const newPrice = variationData.filter((item) => item.attributes[0].option === target.value)[0].price;
+    const newPrice = variationData.find((item) => item.attributes[0].option === target.value).price;
 
     setSize(e.target.value);
     setPrice(newPrice);

--- a/pages/shop/[pid].js
+++ b/pages/shop/[pid].js
@@ -1,29 +1,58 @@
 import React, { useContext, useState } from 'react';
-import { useRouter } from 'next/router';
 
 import Head from 'next/head';
 import Link from 'next/link';
 
-import Button from '@material-ui/core/Button';
-
 import { CartContext } from '../../src/contexts/CartContext';
+import { getProduct } from '../../lib/api';
 
-import { getProducts, getProduct } from '../../lib/api';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
+import MenuItem from '@material-ui/core/MenuItem';
+import { makeStyles } from '@material-ui/core/styles';
 
-export default function Product({ productData }) {
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    margin: '1rem',
+    '& .MuiTextField-root': {
+      margin: theme.spacing(1),
+      width: '10rem',
+    },
+  },
+}));
+
+export default function Product({ productData, variationData }) {
   const { addProduct, cartItems, increase } = useContext(CartContext);
+  const classes = useStyles();
 
   const [quantity, setQuantity] = useState(0);
+  const [size, setSize] = useState('A2');
 
-  console.log('rendering');
+  let startPrice = variationData.filter((item) => item.attributes[0].option === 'A2')[0].price;
+  const [price, setPrice] = useState(startPrice);
+
   const isInCart = (product) => {
     return !!cartItems.find((item) => item.id === product.id);
   };
 
   const addToCart = (productData) => {
-    productData.quantity = parseInt(quantity);
-    addProduct(productData);
+    const selectedVariation = variationData.filter((item) => item.attributes[0].option === size)[0];
+
+    selectedVariation.quantity = quantity;
+    selectedVariation.product_id = productData.id;
+
+    addProduct(selectedVariation);
+  };
+
+  const handleChange = (e) => {
+    const target = e.target;
+
+    const newPrice = variationData.filter((item) => item.attributes[0].option === target.value)[0].price;
+
+    setSize(e.target.value);
+    setPrice(newPrice);
   };
 
   return (
@@ -33,44 +62,42 @@ export default function Product({ productData }) {
         <link rel="icon" href="favicon.ico" />
       </Head>
 
-      <main>
-        <div>
+      <Grid container spacing={0} orientation="row" className={classes.root}>
+        <Grid item>
           <div>{productData.name}</div>
-          {isInCart(productData) && (
-            <Button variant="outlined" onClick={() => increase(productData)}>
-              Increase
-            </Button>
-          )}
-
+          <div>{price}</div>
+          <div>
+            <TextField id="select-variation" select label="Size" value={size} onChange={handleChange} helperText="Select Variation">
+              {variationData?.map((variation) => (
+                <MenuItem key={variation.id} value={variation.attributes[0].option}>
+                  {variation.attributes[0].option}
+                </MenuItem>
+              ))}
+            </TextField>
+          </div>
+        </Grid>
+        <Grid container className={classes.root}>
           {!isInCart(productData) && (
-            <div>
+            <Grid item>
               <Button variant="outlined" onClick={() => addToCart(productData)}>
                 Add to cart
               </Button>
               <TextField id="quantity-field" label="Quantity" type="number" defaultValue={0} InputLabelProps={{ shrink: true }} onChange={(e) => setQuantity(e.target.value)} />
-            </div>
+            </Grid>
           )}
-        </div>
-      </main>
+        </Grid>
+      </Grid>
     </div>
   );
 }
 
-export async function getStaticPaths() {
-  const allProducts = await getProducts();
-
-  return {
-    paths: allProducts.map((product) => `/shop/${product.id}`) || [],
-    fallback: true,
-  };
-}
-
-export async function getStaticProps({ params }) {
-  const data = await getProduct(params.pid);
+export async function getServerSideProps(context) {
+  const data = await getProduct(context.params.pid);
 
   return {
     props: {
-      productData: data,
+      productData: data.product,
+      variationData: data.variations,
     },
   };
 }


### PR DESCRIPTION
Implement product variations for the shop. Allows product variations to be pulled from the WooCommerce REST API and then users can purchase different variations. Support for product variations has also been added to the checkout process.