### PR TITLE
Shopping Cart Icon Navigation bug

### DIFF
--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
     position: 'absolute',
     top: 0,
     backgroundColor: 'transparent',
-    width: '100%',
+    width: '50%',
     minHeight: '75px',
     height: '75px',
     [theme.breakpoints.up('sm')]: {

--- a/components/TopNavbar.js
+++ b/components/TopNavbar.js
@@ -48,9 +48,11 @@ const useStyles = makeStyles((theme) => ({
     padding: 0,
   },
   iconButton: {
-    padding: '35px 3rem 0 1rem',
+    padding: '0px 3rem 0 1rem',
     width: '30px',
     height: '30px',
+    marginTop: 'auto',
+    marginBottom: 'auto',
   },
   iconLink: {
     [theme.breakpoints.down(768)]: {


### PR DESCRIPTION
Fixed the bug where the shopping cart icon was unclickable on the mobile view. This was caused by the `Navigation.js` Toolbar width being `100%`, causing it to overlay the shopping cart button. Set the width to `50%` and seems to be working now.

https://app.gitkraken.com/glo/view/card/929cd872349d4cc3ae2554c086e5084b